### PR TITLE
feat: Return the removed value as part of the Result when calling remove

### DIFF
--- a/benches/overhead_data_size.rs
+++ b/benches/overhead_data_size.rs
@@ -127,7 +127,8 @@ fn use_native_db_get(db: &Database, x: u32) -> Data {
 
 fn native_db_remove(db: &Database, data: Data) {
     let rw = db.rw_transaction().unwrap();
-    rw.remove(data).unwrap();
+    // Remove the old value
+    let _ = rw.remove(data).unwrap();
     rw.commit().unwrap();
 }
 

--- a/src/transaction/rw_transaction.rs
+++ b/src/transaction/rw_transaction.rs
@@ -152,7 +152,7 @@ impl<'db, 'txn> RwTransaction<'db> {
     ///     let rw = db.rw_transaction()?;
     ///
     ///     // Remove a value
-    ///     rw.remove(Data { id: 1 })?;
+    ///     let old_value = rw.remove(Data { id: 1 })?;
     ///
     ///     // /!\ Don't forget to commit the transaction
     ///     rw.commit()?;
@@ -160,14 +160,13 @@ impl<'db, 'txn> RwTransaction<'db> {
     ///     Ok(())
     /// }
     /// ```
-    // TODO: Return the Option<T> of the removed value
-    pub fn remove<T: Input>(&self, item: T) -> Result<()> {
+    pub fn remove<T: Input>(&self, item: T) -> Result<T> {
         let (watcher_request, binary_value) = self
             .internal
             .concrete_remove(T::native_db_model(), item.to_item())?;
-        let event = Event::new_delete(binary_value);
+        let event = Event::new_delete(binary_value.clone());
         self.batch.borrow_mut().add(watcher_request, event);
-        Ok(())
+        Ok(binary_value.inner())
     }
 
     /// Update a value in the database.

--- a/tests/query/insert_remove_pk.rs
+++ b/tests/query/insert_remove_pk.rs
@@ -35,7 +35,8 @@ fn insert_get() {
     assert_eq!(stats.primary_tables[0].n_entries, Some(1));
 
     let rw = db.rw_transaction().unwrap();
-    rw.remove(item.clone()).unwrap();
+    let old_value = rw.remove(item.clone()).unwrap();
+    assert_eq!(old_value, item); 
     rw.commit().unwrap();
 
     let stats = db.redb_stats().unwrap();

--- a/tests/query/insert_remove_sk.rs
+++ b/tests/query/insert_remove_sk.rs
@@ -39,7 +39,8 @@ fn insert_remove() {
     assert_eq!(stats.secondary_tables[0].n_entries, Some(1));
 
     let rw = db.rw_transaction().unwrap();
-    rw.remove(item.clone()).unwrap();
+    let old_value = rw.remove(item.clone()).unwrap();
+    assert_eq!(old_value, item);
     rw.commit().unwrap();
 
     let stats = db.redb_stats().unwrap();
@@ -88,7 +89,8 @@ fn insert_remove_unique_optional() {
     assert_eq!(stats.secondary_tables[0].n_entries, Some(1));
 
     let rw = db.rw_transaction().unwrap();
-    rw.remove(item_1.clone()).unwrap();
+    let old_value = rw.remove(item_1.clone()).unwrap();
+    assert_eq!(old_value, item_1);
     rw.commit().unwrap();
 
     let stats = db.redb_stats().unwrap();
@@ -100,7 +102,8 @@ fn insert_remove_unique_optional() {
     assert_eq!(stats.secondary_tables[0].n_entries, Some(0));
 
     let rw = db.rw_transaction().unwrap();
-    rw.remove(item_2.clone()).unwrap();
+    let old_value = rw.remove(item_2.clone()).unwrap();
+    assert_eq!(old_value, item_2);
     rw.commit().unwrap();
 
     let stats = db.redb_stats().unwrap();

--- a/tests/watch/mod.rs
+++ b/tests/watch/mod.rs
@@ -407,7 +407,8 @@ fn watch_all_delete() {
     recv.recv_timeout(TIMEOUT).unwrap();
 
     let rw = db.rw_transaction().unwrap();
-    rw.remove(item_a.clone()).unwrap();
+    let old = rw.remove(item_a.clone()).unwrap();
+    assert_eq!(old, item_a);
     rw.commit().unwrap();
 
     for _ in 0..1 {


### PR DESCRIPTION
This patch addresses a TODO to return the removed value when calling remove. Now native returns the removed value in the Result