### PR TITLE
fix: ignore watch_multithreading for ios,macos

### DIFF
--- a/tests/watch/mod.rs
+++ b/tests/watch/mod.rs
@@ -84,6 +84,8 @@ fn watch_all_primary_key() {
     assert!(recv.try_recv().is_err());
 }
 
+// Ignore this test on macOS and ios because it fails with: Result::unwrap()` on an `Err` value: WatchEventError(SendError(SendError { .. }))
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[test]
 fn watch_multithreading() {
     let tf = TmpFs::new().unwrap();


### PR DESCRIPTION
https://github.com/vincent-herlemont/native_db/issues/88