### PR TITLE
Add additional ToKey implementations for uuid and chrono. Add support support for ulid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ semver = "1"
 
 uuid = { version = "1.10.0" , optional = true }
 chrono = { version = "0.4" , optional = true }
+ulid = { version = "1.1.3", optional = true }
 
 # Optional tokio support
 tokio = { version = "1.39.1", features = ["sync"], optional = true }
@@ -42,6 +43,7 @@ criterion = { version = "0.5.1" }
 doc-comment = "0.3.3"
 uuid = { version = "1.10.0", features = ["serde", "v4"] }
 chrono = { version = "0.4", features = ["serde"] }
+ulid = { version = "1.1.3", features = ["serde"] }
 rand = "0.8.5"
 once_cell = "1.19"
 dinghy-test = "0.7.2"

--- a/tests/custom_type/mod.rs
+++ b/tests/custom_type/mod.rs
@@ -4,4 +4,7 @@ mod chrono;
 #[cfg(feature = "uuid")]
 mod uuid;
 
+#[cfg(feature = "ulid")]
+mod ulid;
+
 mod custom;

--- a/tests/custom_type/ulid.rs
+++ b/tests/custom_type/ulid.rs
@@ -2,50 +2,46 @@ use native_db::*;
 use native_model::{native_model, Model};
 use serde::{Deserialize, Serialize};
 use shortcut_assert_fs::TmpFs;
-use uuid::Uuid;
+use ulid::Ulid;
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Clone, Debug)]
 #[native_model(id = 1, version = 1)]
 #[native_db]
-struct Item {
+struct UlidItem {
     #[primary_key]
-    uuid: Uuid,
+    ulid: Ulid,
 }
 
 #[test]
-fn insert_get_borrowed_uuid() {
-    let item = Item {
-        uuid: Uuid::new_v4(),
-    };
+fn insert_get_borrowed_ulid() {
+    let item = UlidItem { ulid: Ulid::new() };
     let tf = TmpFs::new().unwrap();
     let mut models = Models::new();
-    models.define::<Item>().unwrap();
+    models.define::<UlidItem>().unwrap();
     let db = Builder::new()
-        .create(&models, tf.path("test_borrowed").as_std_path())
+        .create(&models, tf.path("test_borrowed_ulid").as_std_path())
         .unwrap();
     let rw = db.rw_transaction().unwrap();
     rw.insert(item.clone()).unwrap();
     rw.commit().unwrap();
     let r = db.r_transaction().unwrap();
-    let result_item = r.get().primary(&item.uuid).unwrap().unwrap();
+    let result_item = r.get().primary(&item.ulid).unwrap().unwrap();
     assert_eq!(item, result_item);
 }
 
 #[test]
-fn insert_get_owned_uuid() {
-    let item = Item {
-        uuid: Uuid::new_v4(),
-    };
+fn insert_get_owned_ulid() {
+    let item = UlidItem { ulid: Ulid::new() };
     let tf = TmpFs::new().unwrap();
     let mut models = Models::new();
-    models.define::<Item>().unwrap();
+    models.define::<UlidItem>().unwrap();
     let db = Builder::new()
-        .create(&models, tf.path("test_owned").as_std_path())
+        .create(&models, tf.path("test_owned_ulid").as_std_path())
         .unwrap();
     let rw = db.rw_transaction().unwrap();
     rw.insert(item.clone()).unwrap();
     rw.commit().unwrap();
     let r = db.r_transaction().unwrap();
-    let result_item = r.get().primary(item.uuid).unwrap().unwrap();
+    let result_item = r.get().primary(item.ulid).unwrap().unwrap();
     assert_eq!(item, result_item);
 }


### PR DESCRIPTION
I ran into this issue when trying to use uuids as primary keys:

the trait `native_db::ToKey` is not implemented for `uuid::Uuid`

So I've implemented the ToKey trait for an owned Uuid. I've also added support for ulid and some more chrono types.

Hope you can use it!