### PR TITLE
ToKey implementation for Serializable types.

### DIFF
--- a/src/db_type/key/key_serializer.rs
+++ b/src/db_type/key/key_serializer.rs
@@ -11,7 +11,7 @@ use serde::{
 use super::Key;
 
 #[derive(thiserror::Error, Debug)]
-enum KeySerializerError {
+pub(crate) enum KeySerializerError {
     #[error("unknown error")]
     Unknown(String),
 }
@@ -25,7 +25,19 @@ impl Error for KeySerializerError {
     }
 }
 
-struct KeySerializer(Key);
+pub(crate) struct KeySerializer(Key);
+
+impl KeySerializer {
+    pub(crate) fn new() -> KeySerializer {
+        KeySerializer(Key::new(vec![]))
+    }
+}
+
+impl Into<Key> for KeySerializer {
+    fn into(self) -> Key {
+        self.0
+    }
+}
 
 impl<'a> Serializer for &'a mut KeySerializer {
     type Ok = ();

--- a/src/db_type/key/key_serializer.rs
+++ b/src/db_type/key/key_serializer.rs
@@ -5,7 +5,7 @@ use serde::{
         Error, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
         SerializeTupleStruct, SerializeTupleVariant,
     },
-    Serializer,
+    Serialize, Serializer,
 };
 
 use super::Key;
@@ -47,159 +47,179 @@ impl<'a> Serializer for &'a mut KeySerializer {
     type SerializeStructVariant = Self;
 
     fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.0
+            .extend(&Key::new(u32::from(v).to_be_bytes().to_vec()));
+        Ok(())
     }
 
     fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.0.extend(&Key::new(v.to_be_bytes().to_vec()));
+        Ok(())
     }
 
     fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.0.extend(&Key::new(v.to_be_bytes().to_vec()));
+        Ok(())
     }
 
     fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.0.extend(&Key::new(v.to_be_bytes().to_vec()));
+        Ok(())
     }
 
     fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.0.extend(&Key::new(v.to_be_bytes().to_vec()));
+        Ok(())
     }
 
     fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.0.extend(&Key::new(v.to_be_bytes().to_vec()));
+        Ok(())
     }
 
     fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.0.extend(&Key::new(v.to_be_bytes().to_vec()));
+        Ok(())
     }
 
     fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.0.extend(&Key::new(v.to_be_bytes().to_vec()));
+        Ok(())
     }
 
     fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.0.extend(&Key::new(v.to_be_bytes().to_vec()));
+        Ok(())
     }
 
     fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.0.extend(&Key::new(v.to_be_bytes().to_vec()));
+        Ok(())
     }
 
     fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.0.extend(&Key::new(v.to_be_bytes().to_vec()));
+        Ok(())
     }
 
     fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.0
+            .extend(&Key::new(u32::from(v).to_be_bytes().to_vec()));
+        Ok(())
     }
 
     fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.0.extend(&Key::new(v.as_bytes().to_vec()));
+        Ok(())
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.0.extend(&Key::new(v.to_vec()));
+        Ok(())
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        Ok(())
     }
 
     fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
         T: ?Sized + serde::Serialize,
     {
-        todo!()
+        value.serialize(self)
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        Ok(())
     }
 
-    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
-        todo!()
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Ok(())
     }
 
     fn serialize_unit_variant(
         self,
-        name: &'static str,
+        _name: &'static str,
         variant_index: u32,
-        variant: &'static str,
+        _variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        variant_index.serialize(self)
     }
 
     fn serialize_newtype_struct<T>(
         self,
-        name: &'static str,
+        _name: &'static str,
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
         T: ?Sized + serde::Serialize,
     {
-        todo!()
+        value.serialize(self)
     }
 
     fn serialize_newtype_variant<T>(
         self,
-        name: &'static str,
+        _name: &'static str,
         variant_index: u32,
-        variant: &'static str,
+        _variant: &'static str,
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
         T: ?Sized + serde::Serialize,
     {
-        todo!()
+        variant_index.serialize(&mut *self)?;
+        value.serialize(&mut *self)?;
+        Ok(())
     }
 
-    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        todo!()
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Ok(self)
     }
 
-    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        todo!()
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Ok(self)
     }
 
     fn serialize_tuple_struct(
         self,
-        name: &'static str,
-        len: usize,
+        _name: &'static str,
+        _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        todo!()
+        Ok(self)
     }
 
     fn serialize_tuple_variant(
         self,
-        name: &'static str,
+        _name: &'static str,
         variant_index: u32,
-        variant: &'static str,
-        len: usize,
+        _variant: &'static str,
+        _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        todo!()
+        variant_index.serialize(&mut *self)?;
+        Ok(self)
     }
 
-    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        todo!()
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Ok(self)
     }
 
     fn serialize_struct(
         self,
-        name: &'static str,
-        len: usize,
+        _name: &'static str,
+        _len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        todo!()
+        Ok(self)
     }
 
     fn serialize_struct_variant(
         self,
-        name: &'static str,
+        _name: &'static str,
         variant_index: u32,
-        variant: &'static str,
-        len: usize,
+        _variant: &'static str,
+        _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        todo!()
+        variant_index.serialize(&mut *self)?;
+        Ok(self)
     }
 }
 
@@ -212,11 +232,12 @@ impl<'a> SerializeSeq for &'a mut KeySerializer {
     where
         T: ?Sized + serde::Serialize,
     {
-        todo!()
+        value.serialize(&mut **self)?;
+        Ok(())
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        Ok(())
     }
 }
 
@@ -229,11 +250,12 @@ impl<'a> SerializeTuple for &'a mut KeySerializer {
     where
         T: ?Sized + serde::Serialize,
     {
-        todo!()
+        value.serialize(&mut **self)?;
+        Ok(())
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        Ok(())
     }
 }
 
@@ -246,11 +268,12 @@ impl<'a> SerializeTupleStruct for &'a mut KeySerializer {
     where
         T: ?Sized + serde::Serialize,
     {
-        todo!()
+        value.serialize(&mut **self)?;
+        Ok(())
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        Ok(())
     }
 }
 
@@ -263,11 +286,12 @@ impl<'a> SerializeTupleVariant for &'a mut KeySerializer {
     where
         T: ?Sized + serde::Serialize,
     {
-        todo!()
+        value.serialize(&mut **self)?;
+        Ok(())
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        Ok(())
     }
 }
 
@@ -280,18 +304,20 @@ impl<'a> SerializeMap for &'a mut KeySerializer {
     where
         T: ?Sized + serde::Serialize,
     {
-        todo!()
+        key.serialize(&mut **self)?;
+        Ok(())
     }
 
     fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
         T: ?Sized + serde::Serialize,
     {
-        todo!()
+        value.serialize(&mut **self)?;
+        Ok(())
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        Ok(())
     }
 }
 
@@ -300,15 +326,16 @@ impl<'a> SerializeStruct for &'a mut KeySerializer {
 
     type Error = KeySerializerError;
 
-    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<(), Self::Error>
     where
         T: ?Sized + serde::Serialize,
     {
-        todo!()
+        value.serialize(&mut **self)?;
+        Ok(())
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        Ok(())
     }
 }
 
@@ -317,14 +344,15 @@ impl<'a> SerializeStructVariant for &'a mut KeySerializer {
 
     type Error = KeySerializerError;
 
-    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<(), Self::Error>
     where
         T: ?Sized + serde::Serialize,
     {
-        todo!()
+        value.serialize(&mut **self)?;
+        Ok(())
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        Ok(())
     }
 }

--- a/src/db_type/key/key_serializer.rs
+++ b/src/db_type/key/key_serializer.rs
@@ -1,0 +1,330 @@
+use std::fmt::Display;
+
+use serde::{
+    ser::{
+        Error, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
+        SerializeTupleStruct, SerializeTupleVariant,
+    },
+    Serializer,
+};
+
+use super::Key;
+
+#[derive(thiserror::Error, Debug)]
+enum KeySerializerError {
+    #[error("unknown error")]
+    Unknown(String),
+}
+
+impl Error for KeySerializerError {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: Display,
+    {
+        Self::Unknown(format!("{msg})"))
+    }
+}
+
+struct KeySerializer(Key);
+
+impl<'a> Serializer for &'a mut KeySerializer {
+    type Ok = ();
+
+    type Error = KeySerializerError;
+
+    type SerializeSeq = Self;
+
+    type SerializeTuple = Self;
+
+    type SerializeTupleStruct = Self;
+
+    type SerializeTupleVariant = Self;
+
+    type SerializeMap = Self;
+
+    type SerializeStruct = Self;
+
+    type SerializeStructVariant = Self;
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        todo!()
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        todo!()
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        todo!()
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_struct_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        todo!()
+    }
+}
+
+impl<'a> SerializeSeq for &'a mut KeySerializer {
+    type Ok = ();
+
+    type Error = KeySerializerError;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        todo!()
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+}
+
+impl<'a> SerializeTuple for &'a mut KeySerializer {
+    type Ok = ();
+
+    type Error = KeySerializerError;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        todo!()
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+}
+
+impl<'a> SerializeTupleStruct for &'a mut KeySerializer {
+    type Ok = ();
+
+    type Error = KeySerializerError;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        todo!()
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+}
+
+impl<'a> SerializeTupleVariant for &'a mut KeySerializer {
+    type Ok = ();
+
+    type Error = KeySerializerError;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        todo!()
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+}
+
+impl<'a> SerializeMap for &'a mut KeySerializer {
+    type Ok = ();
+
+    type Error = KeySerializerError;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        todo!()
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        todo!()
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+}
+
+impl<'a> SerializeStruct for &'a mut KeySerializer {
+    type Ok = ();
+
+    type Error = KeySerializerError;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        todo!()
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+}
+
+impl<'a> SerializeStructVariant for &'a mut KeySerializer {
+    type Ok = ();
+
+    type Error = KeySerializerError;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        todo!()
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+}

--- a/src/db_type/key/mod.rs
+++ b/src/db_type/key/mod.rs
@@ -1,7 +1,7 @@
 mod key;
 mod key_definition;
-mod key_value;
 mod key_serializer;
+mod key_value;
 
 #[cfg(feature = "redb1")]
 pub mod inner_key_value_redb1;

--- a/src/db_type/key/mod.rs
+++ b/src/db_type/key/mod.rs
@@ -1,6 +1,7 @@
 mod key;
 mod key_definition;
 mod key_value;
+mod key_serializer;
 
 #[cfg(feature = "redb1")]
 pub mod inner_key_value_redb1;

--- a/tests/custom_type/custom.rs
+++ b/tests/custom_type/custom.rs
@@ -1,19 +1,10 @@
-use native_db::{
-    db_type::{Key, ToKey},
-    native_db, Builder, Models,
-};
+use native_db::{db_type::ToKey, native_db, Builder, Models};
 use native_model::{native_model, Model};
 use serde::{Deserialize, Serialize};
 use shortcut_assert_fs::TmpFs;
 
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone)]
 struct City(String);
-
-impl ToKey for &City {
-    fn to_key(&self) -> Key {
-        Key::new(self.0.as_bytes().to_vec())
-    }
-}
 
 // Test genrate fields:
 // - primary_key


### PR DESCRIPTION
I have encountered a problem, where I wanted to use third-party type as a primary key. Thanks to Rust policy against orphans, it is not possible to implement `ToKey` trait for it.

As the type I wanted to use was serde compatible, I implemented generic `ToKey` for `serde::Serialize` types:

``` rust
impl<T: Serialize + Debug> ToKey for T {
    fn to_key(&self) -> Key {
        let mut serializer = KeySerializer::new();
        self.serialize(&mut serializer).unwrap();
        serializer.into()
    }
}
```

Together with `KeySerializer`, which is backward compatible with the old implementation.

It covers wider range of types, and therefore some assumption how some types have to be processed were made. In particular enum types are serialized by their option indexes. This require from end-user to extend such types in specific way to keep backward compatibility. 


Additionally, I believe, if this could ever made its way to the main branch following things have to be handled:
- wrap in opt-in package feature
- expand documentation
- write some tests covering design decisions
- cleanup interface