### PR TITLE
Remove rust-skeptic dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ description = "Drop-in embedded database"
 license = "MIT"
 repository = "https://github.com/vincent-herlemont/native_db"
 readme = "README.md"
-build = "build.rs"
 keywords = ["embedded-database", "database", "multi-platform", "android", "ios"]
 categories = ["database-implementations", "concurrency", "data-structures", "caching", "algorithms"]
 
@@ -33,7 +32,6 @@ tokio = { version = "1.41.0", features = ["sync"], optional = true }
 assert_fs = "1.1.2"
 serial_test = { version = "3.1.1", features = ["file_locks"] }
 shortcut_assert_fs = { version = "0.1.0" }
-skeptic = "0.13.7"
 tokio = { version = "1.41.0", features = ["test-util","macros"] }
 bincode = { version = "2.0.0-rc.3", features = ["serde"] }
 criterion = { version = "0.5.1" }

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,0 @@
-extern crate skeptic;
-
-fn main() {
-    {
-        // Run skeptic
-        skeptic::generate_doc_tests(&["README.md"]);
-    }
-}


### PR DESCRIPTION
This removes the dependency on [skeptic](https://github.com/budziq/rust-skeptic), fixing #250.

I took the approach of considering `#[doc = include_str!("../../README.md")]`, which by chance was already [there](https://github.com/vincent-herlemont/native_db/blob/63a46a92c157677c300dc9e7fa12a27c89fb07e8/src/lib.rs#L390), scoped to `doctest` only.