### PR TITLE
Re-export native_model, closes #301

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,7 @@ Add this to your `Cargo.toml`:
 ```toml
 [dependencies]
 native_db = "0.8.1"
-native_model = "0.4.20"
 ```
-
-NOTE: `native_db` requires `native_model` to work.
 
 # Status
 
@@ -59,7 +56,7 @@ If you want to propose your project or company that uses Native DB, please open 
 ```rust
 use serde::{Deserialize, Serialize};
 use native_db::*;
-use native_model::{native_model, Model};
+use native_db::native_model::{native_model, Model};
 use once_cell::sync::Lazy;
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]

--- a/src/db_type/key/key.rs
+++ b/src/db_type/key/key.rs
@@ -28,7 +28,7 @@ impl Key {
 /// ## Example
 /// ```rust
 /// use native_db::*;
-/// use native_model::{native_model, Model};
+/// use native_db::native_model::{native_model, Model};
 /// use serde::{Deserialize, Serialize};
 ///
 /// #[derive(Debug, Deserialize, Serialize)]
@@ -77,7 +77,7 @@ impl Key {
 ///
 /// ```rust
 /// use native_db::*;
-/// use native_model::{native_model, Model};
+/// use native_db::native_model::{native_model, Model};
 /// use serde::{Deserialize, Serialize};
 ///
 /// #[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone, Hash)]
@@ -124,7 +124,7 @@ impl Key {
 ///
 /// ```rust
 /// use native_db::*;
-/// use native_model::{native_model, Model};
+/// use native_db::native_model::{native_model, Model};
 /// use serde::{Deserialize, Serialize};
 /// use itertools::Itertools;
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,11 @@
 //!
 //! ```rust
 //! pub mod data {
-//!     use native_db::{native_db, ToKey};
-//!     use native_model::{native_model, Model};
+//!     use native_db::{
+//!         native_db,
+//!         native_model::{self, native_model, Model},
+//!         ToKey,
+//!     };
 //!     use serde::{Deserialize, Serialize};
 //!
 //!     pub type Person = v1::Person;
@@ -111,8 +114,11 @@
 //!
 //! ```rust
 //! # pub mod data {
-//! #     use native_db::{native_db, ToKey};
-//! #     use native_model::{native_model, Model};
+//! #     use native_db::{
+//! #         native_db,
+//! #         native_model::{self, native_model, Model},
+//! #         ToKey,
+//! #     };
 //! #     use serde::{Deserialize, Serialize};
 //! #
 //! #     pub type Person = v1::Person;
@@ -156,8 +162,11 @@
 //!
 //! ```rust
 //! # pub mod data {
-//! #     use native_db::{native_db, ToKey};
-//! #     use native_model::{native_model, Model};
+//! #     use native_db::{
+//! #         native_db,
+//! #         native_model::{self, native_model, Model},
+//! #         ToKey,
+//! #     };
 //! #     use serde::{Deserialize, Serialize};
 //! #
 //! #     pub type Person = v1::Person;
@@ -213,8 +222,11 @@
 //! ```rust
 //! pub mod data {
 //!     // ... same imports
-//! #    use native_db::{native_db, ToKey};
-//! #    use native_model::{native_model, Model};
+//! #     use native_db::{
+//! #         native_db,
+//! #         native_model::{self, native_model, Model},
+//! #         ToKey,
+//! #     };
 //! #    use serde::{Deserialize, Serialize};
 //!     
 //!     // Update the type alias to the latest version
@@ -271,8 +283,11 @@
 //! ```rust
 //! # pub mod data {
 //! #    // ... same imports
-//! #    use native_db::{native_db, ToKey};
-//! #    use native_model::{native_model, Model};
+//! #     use native_db::{
+//! #         native_db,
+//! #         native_model::{self, native_model, Model},
+//! #         ToKey,
+//! #     };
 //! #    use serde::{Deserialize, Serialize};
 //! #    
 //! #    // Update the type alias to the latest version
@@ -374,6 +389,7 @@ pub use db_type::Key;
 pub use db_type::ToInput;
 /// Allow to use a type as a key in the database.
 pub use db_type::ToKey;
+pub use native_model;
 
 // Export
 pub use database::*;

--- a/src/models.rs
+++ b/src/models.rs
@@ -17,8 +17,11 @@ use crate::{db_type::Result, table_definition::NativeModelOptions, ModelBuilder,
 ///
 /// ```rust
 /// # pub mod data {
-/// #     use native_db::{native_db, ToKey};
-/// #     use native_model::{native_model, Model};
+/// #     use native_db::{
+/// #         native_db,
+/// #         native_model::{self, native_model, Model},
+/// #         ToKey,
+/// #     };
 /// #     use serde::{Deserialize, Serialize};
 /// #
 /// #     pub type Person = v1::Person;
@@ -107,7 +110,7 @@ impl Models {
     ///
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]
@@ -131,7 +134,7 @@ impl Models {
     ///
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]
@@ -176,7 +179,7 @@ impl Models {
     ///
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]
@@ -198,7 +201,7 @@ impl Models {
     ///
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]
@@ -237,7 +240,7 @@ impl Models {
     ///
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]
@@ -280,7 +283,7 @@ impl Models {
     ///
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]

--- a/src/transaction/query/get.rs
+++ b/src/transaction/query/get.rs
@@ -17,7 +17,7 @@ impl RGet<'_, '_> {
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]
@@ -62,7 +62,7 @@ impl RGet<'_, '_> {
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]

--- a/src/transaction/query/len.rs
+++ b/src/transaction/query/len.rs
@@ -14,7 +14,7 @@ impl RLen<'_, '_> {
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]
@@ -54,7 +54,7 @@ impl RLen<'_, '_> {
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]

--- a/src/transaction/query/scan/primary_scan.rs
+++ b/src/transaction/query/scan/primary_scan.rs
@@ -28,7 +28,7 @@ where
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     /// use itertools::Itertools;
     ///
@@ -66,7 +66,7 @@ where
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     /// use itertools::Itertools;
     ///
@@ -109,7 +109,7 @@ where
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     /// use itertools::Itertools;
     ///

--- a/src/transaction/query/scan/secondary_scan.rs
+++ b/src/transaction/query/scan/secondary_scan.rs
@@ -47,7 +47,7 @@ where
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     /// use itertools::Itertools;
     ///
@@ -98,7 +98,7 @@ where
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     /// use itertools::Itertools;
     ///
@@ -157,7 +157,7 @@ where
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     /// use itertools::Itertools;
     ///

--- a/src/transaction/rw_transaction.rs
+++ b/src/transaction/rw_transaction.rs
@@ -102,7 +102,7 @@ impl<'db, 'txn> RwTransaction<'db> {
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]
@@ -148,7 +148,7 @@ impl<'db, 'txn> RwTransaction<'db> {
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]
@@ -216,7 +216,7 @@ impl<'db, 'txn> RwTransaction<'db> {
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]
@@ -266,7 +266,7 @@ impl<'db, 'txn> RwTransaction<'db> {
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]
@@ -314,7 +314,7 @@ impl<'db, 'txn> RwTransaction<'db> {
     ///
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize, Clone)]
@@ -402,7 +402,7 @@ impl<'db, 'txn> RwTransaction<'db> {
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize, Debug)]

--- a/src/watch/query/get.rs
+++ b/src/watch/query/get.rs
@@ -20,7 +20,7 @@ impl WatchGet<'_, '_> {
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]
@@ -58,7 +58,7 @@ impl WatchGet<'_, '_> {
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]

--- a/src/watch/query/scan.rs
+++ b/src/watch/query/scan.rs
@@ -49,7 +49,7 @@ impl WatchScanPrimary<'_, '_> {
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]
@@ -90,7 +90,7 @@ impl WatchScanPrimary<'_, '_> {
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]
@@ -136,7 +136,7 @@ impl WatchScanSecondary<'_, '_> {
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]
@@ -178,7 +178,7 @@ impl WatchScanSecondary<'_, '_> {
     /// # Example
     /// ```rust
     /// use native_db::*;
-    /// use native_model::{native_model, Model};
+    /// use native_db::native_model::{native_model, Model};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Serialize, Deserialize)]

--- a/version_update.sh
+++ b/version_update.sh
@@ -41,7 +41,6 @@ do
 
       # Use sed to find and replace the version string in the README.md
       sed -i -E "s/native_db = \"[0-9]+\.[0-9]+\.[0-9]+\"/native_db = \"$NEW_VERSION\"/g" "$directory/README.md"
-      sed -i -E "s/native_model = \"[0-9]+\.[0-9]+\.[0-9]+\"/native_model = \"$NATIVE_MODEL_VERSION\"/g" "$directory/README.md"
 
       # Replace on src/metadata/current_version.rs: const CURRENT_VERSION: &str = "x.x.x";
       sed -i -E "s/pub const CURRENT_VERSION: \&str = \"[0-9]+\.[0-9]+\.[0-9]+\";/pub const CURRENT_VERSION: \&str = \"$NEW_VERSION\";/g" "$directory/src/metadata/current_version.rs"


### PR DESCRIPTION
Imports look weird now. `native_model::self` is necessary because `#[native_model]` macro assumes its visibility.

I've tried `pub use native_model::{native_model, Model}`, which would simplify the imports, but it's not easy to re-export a proc macro and there's a conflicting `pub use model::Model`.

So, I'm ok if you change your mind on the re-exporting, but I still think it's better than manually fitting versions.