### PR TITLE
Fixed grammar in READMEs and Rust doc comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,20 @@
 [![Documentation](https://docs.rs/native_db/badge.svg)](https://docs.rs/native_db)
 [![License](https://img.shields.io/crates/l/native_db)](LICENSE)
 
-Here's a drop-in, fast, embedded database for multi-platform apps (server, desktop, mobile). Sync Rust types effortlessly. Enjoy! 😌🍃.
+A drop-in, fast, embedded database for multi-platform apps (server, desktop, mobile). Sync Rust types effortlessly. Enjoy! 😌🍃
 
 # Features
 
-- Simple API 🦀.
+- Simple API 🦀
 - Support for **multiple indexes** (primary, secondary, unique, non-unique, optional).
-- Fast, see [`sqlite` vs `redb` vs `native_db`](./benches/README.md) benchmarks.
-- Transparent serialization/deserialization using [native_model](https://github.com/vincent-herlemont/native_model). You can use any serialization library you want (`bincode`, `postcard`, your own etc.).
-- Ensure query **type safety** to prevent unexpected results caused by selecting with an incorrect type.
-- **Automatic model migration** 🌟.
-- **Thread-safe** and fully **ACID-compliant** transactions provided by [redb](https://github.com/cberner/redb).
-- **Real-time** subscription with filters for `insert`, `update` and `delete` operations.
-- Compatible with all Rust types (`enum`, `struct`, `tuple` etc.).
-- **Hot snapshots**.
+- Fast; see [`sqlite` vs `redb` vs `native_db`](./benches/README.md) benchmarks.
+- Transparent serialization/deserialization using [native_model](https://github.com/vincent-herlemont/native_model). You can use any serialization library you want (`bincode`, `postcard`, your own, etc.).
+- Ensures query **type safety** to prevent unexpected results caused by selecting with an incorrect type.
+- **Automatic model migration** 🌟
+- **Thread-safe** and fully **ACID-compliant** transactions provided by [Redb](https://github.com/cberner/redb).
+- **Real-time** subscription with filters for `insert`, `update`, and `delete` operations.
+- Compatible with all Rust types (`enum`, `struct`, `tuple`, etc.).
+- **Hot snapshots**
 
 # Installation
 
@@ -37,7 +37,7 @@ native_model = "0.4.20"
 
 # Status
 
-Active development. The API is not stable yet and may change in the future.
+Active development. The API is not yet stable and may change in the future.
 
 # How to use?
 
@@ -50,7 +50,7 @@ Active development. The API is not stable yet and may change in the future.
 - [polly-scheduler](https://github.com/dongbin86/polly-scheduler)
 - [Oku](https://okubrowser.github.io)
 
-If you want to propose your project or company that uses Native DB, please open a PR.
+If you want to add your project or company that uses `Native DB`, please open a PR.
 
 # Example
 
@@ -71,8 +71,8 @@ struct Item {
 }
 
 // Define the models
-// The lifetime of the models needs to be longer or equal to the lifetime of the database.
-// In many cases, it is simpler to use a static variable but it is not mandatory.
+// The lifetime of the models needs to be longer than or equal to the lifetime of the database.
+// In many cases, it is simpler to use a static variable, but it is not mandatory.
 static MODELS: Lazy<Models> = Lazy::new(|| {
     let mut models = Models::new();
     models.define::<Item>().unwrap();
@@ -95,7 +95,7 @@ fn main() -> Result<(), db_type::Error> {
     // Retrieve data with id=3 
     let retrieve_data: Item = r.get().primary(3_u32)?.unwrap();
     println!("data id='3': {:?}", retrieve_data);
-    // Iterate items with name starting with "red"
+    // Iterate over items with names starting with "red"
     for item in r.scan().secondary::<Item>(ItemKey::name)?.start_with("red")? {
         println!("data name=\"red\": {:?}", item);
     }

--- a/benches/README.md
+++ b/benches/README.md
@@ -12,29 +12,29 @@
 ## Overview
 
 
-- :warning: This benchmark is an initial version and it can certainly be greatly improved to make the results as relevant as possible. Feel free to open issues to improve it. 
-- :point_right: Native DB will be further improved in the future as performance issues have not yet been addressed. That is indeed the purpose of this benchmark, which is to provide visibility on what needs to be improved.
+- :warning: This benchmark is an initial version and can certainly be greatly improved to make the results as relevant as possible. Feel free to open issues to improve it.
+- :point_right: Native DB will be further improved in the future, as performance issues have not yet been addressed. That is indeed the purpose of this benchmark: to provide visibility on what needs to be improved.
 
 Comparison between [`Native DB`](https://github.com/vincent-herlemont/native_db) vs [`Redb`](https://github.com/cberner/redb) vs [`SQLite`](https://www.sqlite.org/)
 
 - Why compare with `Redb`?
-  - To highlight the `Native DB` overhead, because `Redb` is the backend of `Native DB`, it should "normally" always be faster than `Native DB`.
+  - To highlight the `Native DB` overhead. Because `Redb` is the backend of `Native DB`, it should normally always be faster than `Native DB`.
 - Why compare with `SQLite`?
-  - Because even though `SQLite` offers a lot more options, `Native DB` can be seen as a very light alternative to `SQLite`.
-- And the other databases?
-  - Knowing the capabilities of `Native DB` compared to `Redb` with the benchmark below, you can check the benchmark of redb here: [cberner/redb/benchmarks](https://github.com/cberner/redb?tab=readme-ov-file#benchmarks)
+  - Because even though `SQLite` offers many more options, `Native DB` can be seen as a very light alternative.
+- And other databases?
+  - Knowing the capabilities of `Native DB` compared to `Redb` with the benchmark below, you can check the `Redb` benchmark here: [cberner/redb/benchmarks](https://github.com/cberner/redb?tab=readme-ov-file#benchmarks)
 
-The benchmarks ignore:
+The benchmarks ignore the following:
  - [`native_model`](https://github.com/vincent-herlemont/native_model) overhead.
- - Serialization overhead used by `native_model` like `bincode`,`postcard` etc.
- - The fact that `redb` can write the data using zero-copy.
+ - Serialization overhead used by `native_model`, such as `bincode`, `postcard`, etc.
+ - The fact that `Redb` can write data using zero-copy.
 
 Explanation:
- - `1:SK`, `10:SK`, `50:SK`, `100:SK`, `N:SK` in this case `N` is the number of secondary keys (`SK`) for the same data. Regarding SQLite, it is the column with each having a secondary index.
+ - `1:SK`, `10:SK`, `50:SK`, `100:SK`, `N:SK`: in this case, `N` is the number of secondary keys (`SK`) for the same data. Regarding `SQLite`, it is the column, with each having a secondary index.
  - `1:T`, `n:T` represent the number of operations per transaction.
-   - `1:T` means one operation per transaction, for example, for insertion, it means there is only one insert operation per transaction.
-   - `n:T` means `n` operations per transaction, `n` is defined by `criterion`, meaning that all operations are within a single transaction.
- - We can see that `Redb` sometimes has no comparisons (`N/A`) because `Redb` is a key-value database and does not support secondary indexes. Therefore, it is pointless to compare with more or fewer secondary indexes.
+   - `1:T` means one operation per transaction. For example, for insertion, it means there is only one insert operation per transaction.
+   - `n:T` means `n` operations per transaction, where `n` is defined by `criterion`, meaning that all operations are within a single transaction.
+ - We can see that `Redb` sometimes has no comparisons (`N/A`) because `Redb` is a key-value database and does not support secondary indexes. Therefore, it is pointless to compare it with more or fewer secondary indexes.
 
 ## Benchmark Results
 
@@ -75,7 +75,7 @@ Explanation:
 
 ### Delete
 
-:warning: We can see that when all operations are in a single transaction (`n:T`), Native DB has a huge overhead. An issue has been created to resolve this problem [#256](https://github.com/vincent-herlemont/native_db/issues/256).
+:warning: We can see that when all operations are in a single transaction (`n:T`), `Native DB` has a huge overhead. An issue has been created to resolve this problem: [#256](https://github.com/vincent-herlemont/native_db/issues/256).
 
 |                       | `Native_db`               | `Native_db_twophasecommit`          | `Native_db_quickrepair`          | `Redb`                          | `Sqlite`                          |
 |:----------------------|:--------------------------|:------------------------------------|:---------------------------------|:--------------------------------|:--------------------------------- |
@@ -90,4 +90,3 @@ Explanation:
 
 ---
 Made with [criterion-table](https://github.com/nu11ptr/criterion-table)
-

--- a/src/database.rs
+++ b/src/database.rs
@@ -44,14 +44,14 @@ impl Database<'_> {
     /// This transaction allows you to read and write data.
     ///
     /// - Write operations:
-    ///     - [`insert`](crate::transaction::RwTransaction::insert) - Insert a item.
-    ///     - [`update`](crate::transaction::RwTransaction::update) - Update a item.
-    ///     - [`remove`](crate::transaction::RwTransaction::remove) - Remove a item.
-    ///     - [`migrate`](crate::transaction::RwTransaction::migrate) - Migrate a model, affect all items.
+    ///     - [`insert`](crate::transaction::RwTransaction::insert) - Insert an item.
+    ///     - [`update`](crate::transaction::RwTransaction::update) - Update an item.
+    ///     - [`remove`](crate::transaction::RwTransaction::remove) - Remove an item.
+    ///     - [`migrate`](crate::transaction::RwTransaction::migrate) - Migrate a model, affecting all items.
     ///     - [`commit`](crate::transaction::RwTransaction::commit) - Commit the transaction.
     ///     - [`abort`](crate::transaction::RwTransaction::abort) - Abort the transaction.
     /// - Read operations:
-    ///    - [`get`](crate::transaction::RwTransaction::get) - Get a item.
+    ///    - [`get`](crate::transaction::RwTransaction::get) - Get an item.
     ///    - [`scan`](crate::transaction::RwTransaction::scan) - Scan items.
     ///    - [`len`](crate::transaction::RwTransaction::len) - Get the number of items.
     pub fn rw_transaction(&self) -> Result<RwTransaction> {
@@ -71,7 +71,7 @@ impl Database<'_> {
     /// This transaction allows you to read data.
     ///
     /// - Read operations:
-    ///   - [`get`](crate::transaction::RTransaction::get) - Get a item.
+    ///   - [`get`](crate::transaction::RTransaction::get) - Get an item.
     ///   - [`scan`](crate::transaction::RTransaction::scan) - Scan items.
     ///   - [`len`](crate::transaction::RTransaction::len) - Get the number of items.
     pub fn r_transaction(&self) -> Result<RTransaction> {
@@ -89,7 +89,7 @@ impl Database<'_> {
 impl Database<'_> {
     /// Watch queries.
     ///
-    /// - [`get`](crate::watch::query::Watch::get) - Watch a item.
+    /// - [`get`](crate::watch::query::Watch::get) - Watch an item.
     /// - [`scan`](crate::watch::query::Watch::scan) - Watch items.
     pub fn watch(&self) -> Watch {
         Watch {
@@ -102,8 +102,8 @@ impl Database<'_> {
 
     /// Unwatch the given `id`.
     /// You can get the `id` from the return value of [`watch`](Self::watch).
-    /// If the `id` is not valid anymore, this function will do nothing and return `false`.
-    /// If the `id` is valid, the corresponding watcher will be removed and return `true`.
+    /// If the `id` is no longer valid, this function will do nothing and return `false`.
+    /// If the `id` is valid, the corresponding watcher will be removed, and the function will return `true`.
     /// If the `id` is valid but the watcher is already removed, this function will return `false`.
     pub fn unwatch(&self, id: u64) -> Result<bool> {
         let mut watchers = self.watchers.write().unwrap();
@@ -161,8 +161,8 @@ impl<'a> Database<'a> {
 
     /// Returns true if the database is upgrading from the given version selector.
     ///
-    /// - If the database is the old version, not matching the selector the function will return `false.
-    /// - If the database is not upgrading, the function will return always `false`.
+    /// - If the database is an older version that does not match the selector, the function will return `false`.
+    /// - If the database is not upgrading, the function will always return `false`.
     ///
     /// Generally used with the method [refresh](crate::transaction::RwTransaction::refresh),
     /// to refresh the data for the given model.

--- a/src/database_builder.rs
+++ b/src/database_builder.rs
@@ -33,7 +33,7 @@ impl Configuration {
         redb_builder
     }
 }
-/// Builder that allows you to create a [`Database`](crate::Database) instance via [`create`](Self::create) or [`open`](Self::open) etc.
+/// Builder that allows you to create a [`Database`](crate::Database) instance via [`create`](Self::create), [`open`](Self::open), etc.
 #[derive(Debug)]
 pub struct Builder {
     database_configuration: Configuration,
@@ -72,7 +72,7 @@ impl Default for Builder {
 }
 
 impl Builder {
-    /// Construct a new [Builder] with sensible defaults.
+    /// Constructs a new [Builder] with sensible defaults.
     pub fn new() -> Self {
         Self {
             database_configuration: Configuration {
@@ -87,7 +87,7 @@ impl Builder {
         self
     }
 
-    /// Creates a new `Db` instance using the given path.
+    /// Creates a new `Database` instance using the given path.
     ///
     /// Similar to [redb::Builder.create(...)](https://docs.rs/redb/latest/redb/struct.Builder.html#method.create)
     pub fn create<'a>(&self, models: &'a Models, path: impl AsRef<Path>) -> Result<Database<'a>> {

--- a/src/db_type/error.rs
+++ b/src/db_type/error.rs
@@ -46,10 +46,10 @@ pub enum Error {
     #[error("IO error")]
     Io(#[from] std::io::Error),
 
-    #[error("Table definition not found {table}")]
+    #[error("Table definition not found for table: {table}")]
     TableDefinitionNotFound { table: String },
 
-    #[error("Secondary key definition not found {table} {key}")]
+    #[error("Secondary key definition not found for table: {table}, key: {key}")]
     SecondaryKeyDefinitionNotFound { table: String, key: String },
 
     #[error("Secondary key constraint mismatch {table} {key} got: {got:?}")]
@@ -59,7 +59,7 @@ pub enum Error {
         got: db_type::KeyOptions,
     },
 
-    #[error("The secondary key {key_name} is not unique ")]
+    #[error("The secondary key '{key_name}' is not unique.")]
     NotUniqueSecondaryKey { key_name: String },
 
     // TODO: key with key name.
@@ -72,7 +72,7 @@ pub enum Error {
     #[error("Duplicate key for \"{key_name}\"")]
     DuplicateKey { key_name: String },
 
-    #[error("Missmatched key type for \"{key_name}\" expected {expected_types:?} got {got_types:?} during {operation:?}")]
+    #[error("Mismatched key type for '{key_name}'. Expected {expected_types:?}, got {got_types:?} during {operation:?}.")]
     MissmatchedKeyType {
         key_name: String,
         expected_types: Vec<String>,
@@ -83,10 +83,10 @@ pub enum Error {
     #[error("Watch event error")]
     WatchEventError(#[from] watch::WatchEventError),
 
-    #[error("Max watcher reached (should be impossible)")]
+    #[error("Maximum number of watchers reached (should be impossible).")]
     MaxWatcherReached,
 
-    #[error("You can not migrate the table {0} because it is a legacy model")]
+    #[error("Cannot migrate table {0} because it is a legacy model.")]
     MigrateLegacyModel(String),
 
     #[error("Model error")]
@@ -95,6 +95,6 @@ pub enum Error {
     #[error("Fail to remove secondary key: {0}")]
     RemoveSecondaryKeyError(String),
 
-    #[error("Inccorect input data it does not match the model")]
+    #[error("Incorrect input data: it does not match the model.")]
     IncorrectInputData { value: Vec<u8> },
 }

--- a/src/db_type/key/key.rs
+++ b/src/db_type/key/key.rs
@@ -20,10 +20,10 @@ impl Key {
     }
 }
 
-/// Allow to use a type as a key in the database.
+/// Allows a type to be used as a key in the database.
 ///
 /// In the below example, we define a struct `City` and implement the `ToKey` trait for it.
-/// It can be use for primary or/and secondary key, and any other type that require `City` as a key.
+/// It can be used for primary and/or secondary keys, and any other type that requires `City` as a key.
 ///
 /// ## Example
 /// ```rust
@@ -62,10 +62,10 @@ impl Key {
 ///     // Open a read transaction
 ///     let r = db.r_transaction()?;
 ///     
-///     // Get contry by the capital city (primary key)
+///     // Get country by the capital city (primary key)
 ///     let _us: Option<Contry> = r.get().primary(City("Washington, D.C.".to_string()))?;
 ///
-///     // Get contry by the bigest city (secondary key)
+///     // Get country by the biggest city (secondary key)
 ///     let _us: Option<Contry> = r.get().secondary(ContryKey::bigest_city, City("New York".to_string()))?;
 ///     Ok(())
 /// }
@@ -73,7 +73,7 @@ impl Key {
 ///
 /// ## Example with `Uuid`
 ///
-/// You can use [uuid](https://crates.io/crates/uuid) crate to generate a `Uuid` key.
+/// You can use the [uuid](https://crates.io/crates/uuid) crate to generate a `Uuid` key.
 ///
 /// ```rust
 /// use native_db::*;
@@ -120,7 +120,7 @@ impl Key {
 ///
 /// ## Example with `chrono`
 ///
-/// You can use [chrono](https://crates.io/crates/chrono) crate to generate a `chrono::DateTime` key.
+/// You can use the [chrono](https://crates.io/crates/chrono) crate to generate a `chrono::DateTime` key.
 ///
 /// ```rust
 /// use native_db::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-//! Native DB is a Rust library that provides a simple, fast, and embedded database solution,
+//! Native DB is a Rust library that provides a simple, fast, embedded database solution,
 //! focusing on maintaining coherence between Rust types and stored data with minimal boilerplate.
-//! It supports multiple indexes, real-time watch with filters, model migration, hot snapshot, and more.
+//! It supports multiple indexes, real-time watch with filters, model migration, hot snapshots, and more.
 //!
 //! # Summary
 //! - [Api](#api)
@@ -28,17 +28,17 @@
 //!    - [`compact`](crate::Database::compact) - Compact the database.
 //!    - [`check_integrity`](crate::Database::check_integrity) - Check the integrity of the database.
 //!    - [`rw_transaction`](crate::Database::rw_transaction) - Create a read-write transaction.
-//!       - [`insert`](crate::transaction::RwTransaction::insert) - Insert a item, fail if the item already exists.
-//!       - [`upsert`](crate::transaction::RwTransaction::upsert) - Upsert a item, update if the item already exists.
-//!       - [`update`](crate::transaction::RwTransaction::update) - Update a item, replace an existing item.
-//!       - [`remove`](crate::transaction::RwTransaction::remove) - Remove a item, remove an existing item.
-//!       - [`migrate`](crate::transaction::RwTransaction::migrate) - Migrate a model, affect all items.
+//!       - [`insert`](crate::transaction::RwTransaction::insert) - Insert an item; fails if the item already exists.
+//!       - [`upsert`](crate::transaction::RwTransaction::upsert) - Upsert an item; updates if the item already exists.
+//!       - [`update`](crate::transaction::RwTransaction::update) - Update an item; replaces an existing item.
+//!       - [`remove`](crate::transaction::RwTransaction::remove) - Remove an item; removes an existing item.
+//!       - [`migrate`](crate::transaction::RwTransaction::migrate) - Migrate a model, affecting all items.
 //!       - [`commit`](crate::transaction::RwTransaction::commit) - Commit the transaction.
 //!       - [`abort`](crate::transaction::RwTransaction::abort) - Abort the transaction.
 //!   - [`r_transaction`](crate::Database::r_transaction) - Create a read-only transaction.
-//!       - [`get`](crate::transaction::RTransaction::get) - Get a item.
-//!          - [`primary`](crate::transaction::query::RGet::primary) - Get a item by primary key.
-//!          - [`secondary`](crate::transaction::query::RGet::secondary) - Get a item by secondary key.
+//!       - [`get`](crate::transaction::RTransaction::get) - Get an item.
+//!          - [`primary`](crate::transaction::query::RGet::primary) - Get an item by primary key.
+//!          - [`secondary`](crate::transaction::query::RGet::secondary) - Get an item by secondary key.
 //!       - [`scan`](crate::transaction::RTransaction::scan) - Scan items.
 //!          - [`primary`](crate::transaction::query::RScan::primary) - Scan items by primary key.
 //!             - [`all`](crate::transaction::query::PrimaryScan::all) - Scan all items.
@@ -51,10 +51,10 @@
 //!       - [`len`](crate::transaction::RTransaction::len) - Get the number of items.
 //!          - [`primary`](crate::transaction::query::RLen::primary) - Get the number of items by primary key.
 //!          - [`secondary`](crate::transaction::query::RLen::secondary) - Get the number of items by secondary key.    
-//!   - [`watch`](crate::Database::watch) - Watch items in real-time.  Works via [std channel](https://doc.rust-lang.org/std/sync/mpsc/fn.channel.html) based or [tokio channel](https://docs.rs/tokio/latest/tokio/sync/mpsc/fn.unbounded_channel.html) based depending on the feature `tokio`.
-//!       - [`get`](crate::watch::query::Watch::get) - Watch a item.
-//!          - [`primary`](crate::watch::query::WatchGet::primary) - Watch a item by primary key.
-//!          - [`secondary`](crate::watch::query::WatchGet::secondary) - Watch a item by secondary key.
+//!   - [`watch`](crate::Database::watch) - Watch items in real-time.  Works via [std channel](https://doc.rust-lang.org/std/sync/mpsc/fn.channel.html) based or [tokio channel](https://docs.rs/tokio/latest/tokio/sync/mpsc/fn.unbounded_channel.html) based depending on whether the `tokio` feature is enabled.
+//!       - [`get`](crate::watch::query::Watch::get) - Watch an item.
+//!          - [`primary`](crate::watch::query::WatchGet::primary) - Watch an item by primary key.
+//!          - [`secondary`](crate::watch::query::WatchGet::secondary) - Watch an item by secondary key.
 //!       - [`scan`](crate::watch::query::Watch::scan) - Watch items.
 //!          - [`primary`](crate::watch::query::WatchScan::primary) - Watch items by primary key.
 //!             - [`all`](crate::watch::query::WatchScanPrimary::all) - Watch all items.
@@ -74,11 +74,11 @@
 //!
 //! > 👉 Unlike the usual database where there is a difference between *schema* and *model*, here, as we can directly use Rust types that are serialized in the database, we do not have the concept of *schema*, only that of the *model*.
 //!
-//! In this section, we will create a simple model. I have chosen a particular organization using Rust modules, which I find to be a best practice. However, it is not mandatory; you can do it as you prefer. (see [`define`](crate::Models::define) for more information)
+//! In this section, we will create a simple model. I have chosen a particular organization using Rust modules, which I find to be good practice. However, this is not mandatory; you can organize it as you prefer. (see [`define`](crate::Models::define) for more information)
 //!
 //! In this example:
 //! - We create a module `data` which contains **all versions of all models**.
-//! - We create a module `v1` which contains the **first version of your data**, we will put other versions later.
+//! - We create a module `v1` which contains the **first version of your data**; we will add other versions later.
 //! - We create a type alias `Person` to the latest version `v1::Person`, which allows us to use the **latest version** of the model in the application.
 //!
 //! ```rust
@@ -110,7 +110,7 @@
 //!
 //! After creating the model in the previous step, we can now create the database with the model.
 //!
-//! Note good practices: [`define`](crate::Models::define) the [`models`](crate::Models) by **specifying each version**, in our case `data::v1::Person`.
+//! Note good practice: [`define`](crate::Models::define) the [`models`](crate::Models) by **specifying each version**; in our case, `data::v1::Person`.
 //!
 //! ```rust
 //! # pub mod data {
@@ -214,7 +214,7 @@
 //!
 //! We need to add the field `age` to the `Person` model, but data is already stored in the database so we need to migrate it.
 //!
-//! To do this we have to:
+//! To do this, we have to:
 //! - Create a version `v2` of the model `Person` with the new field `age`.
 //! - Implement the `From` (or `TryFrom`) trait for the previous version `v1` to the new version `v2`, so we can migrate the data.
 //!   See [native_model#Data model](https://github.com/vincent-herlemont/native_model?tab=readme-ov-file#data-model) for more information.
@@ -361,13 +361,13 @@
 //! }
 //! ```
 //!
-//! More details [`migrate`](crate::transaction::RwTransaction::migrate) method.
+//! See the [`migrate`](crate::transaction::RwTransaction::migrate) method for more details.
 //!
 mod database;
 mod database_builder;
 mod database_instance;
 
-/// A collection of type used by native_db internally (macro included).
+/// A collection of types used by native_db internally (including macros).
 pub mod db_type;
 mod metadata;
 mod model;

--- a/src/models.rs
+++ b/src/models.rs
@@ -9,7 +9,7 @@ use crate::{db_type::Result, table_definition::NativeModelOptions, ModelBuilder,
 /// of defining and manipulating them within your application.
 ///
 /// # Note
-/// Usually, there is little point in creating models at runtime. In some cases, it is necessary to define them with a `'static` lifetime, for example, to address compatibility issues with certain asynchronous libraries such as [Axum](https://github.com/tokio-rs/axum).
+/// Usually, there is little point in creating models at runtime. In some cases, it is necessary to define them with a `'static` lifetime—for example, to address compatibility issues with certain asynchronous libraries such as [Axum](https://github.com/tokio-rs/axum).
 /// There are multiple ways to achieve this, including the [`once_cell::sync::Lazy`](https://docs.rs/once_cell/1.19.0/once_cell/sync/struct.Lazy.html) crate,
 /// or the [`LazyLock`](https://doc.rust-lang.org/std/sync/struct.LazyLock.html) from the standard library, which is available when the relevant Rust feature is enabled.
 ///
@@ -72,8 +72,8 @@ impl Models {
     ///
     /// # Global Options
     ///
-    /// `export_keys`: You can export the keys enum using the `export_keys` option, example: `#[native_db(export_keys = true)]`.
-    /// This option makes the keys enum visible outside of the crate with `pub` visibility, default value is `false` with visibility limited to `pub(crate)`.
+    /// `export_keys`: You can export the keys enum using the `export_keys` option. For example: `#[native_db(export_keys = true)]`.
+    /// This option makes the keys enum visible outside the crate with `pub` visibility. The default value is `false`, with visibility limited to `pub(crate)`.
     ///
     /// # Keys and Models
     ///
@@ -231,10 +231,10 @@ impl Models {
     /// This means that an instance of the model can have a value for the secondary key or not.
     /// When `optional` is set, the value **must** be an [`Option`](https://doc.rust-lang.org/std/option/enum.Option.html).
     /// If the value is not an [`Option`](https://doc.rust-lang.org/std/option/enum.Option.html), the compiler will return
-    /// an error: `error[E0282]: type annotations needed: cannot infer type`.
+    /// an error like: `error[E0282]: type annotations needed cannot infer type`.
     ///
-    /// Under the hood, the secondary key is stored in a separate `redb` table. So if the secondary key is optional,
-    /// the value will be stored in the table only if the value is not `None`.
+    /// Under the hood, the secondary key is stored in a separate `redb` table. Therefore, if the secondary key is optional,
+    /// the value will be stored in the table only if it is not `None`.
     ///
     /// ### Defining a Model with a Custom Optional Secondary Key
     ///
@@ -277,7 +277,7 @@ impl Models {
     /// # Defining Multiple Models
     ///
     /// To define multiple models, you **must** use different `id` values for each model. If you use the same `id` for two models,
-    /// the program will panic with the message: `The table <table_name> has the same native model version as the table <table_name> and it's not allowed`.
+    /// the program will panic with the message: `The table <table_name> has the same native model version as the table <table_name>, and it's not allowed`.
     ///
     /// Example:
     ///
@@ -310,9 +310,8 @@ impl Models {
     /// ```
     ///
     /// In the above example, we have:
-    /// - We have two models, `Animal` and `Vegetable`.
-    /// - Both have:
-    ///   - **One primary key** named `name` of type `String`, defined on the field.
+    /// - Two models, `Animal` and `Vegetable`.
+    /// - Both have one primary key named `name` of type `String`, defined on the field.
     /// - Each model has a unique `id` (`id=1` for `Animal`, `id=2` for `Vegetable`), which is necessary to avoid conflicts.
     pub fn define<T: ToInput>(&mut self) -> Result<()> {
         let mut new_model_builder = ModelBuilder {
@@ -346,7 +345,7 @@ impl Models {
                 }
                 Ordering::Equal => {
                     panic!(
-                        "The table {} has the same native model version as the table {} and it's not allowed",
+                        "The table {} has the same native model version as the table {}, which is not allowed.",
                         model.model.primary_key.unique_table_name,
                         new_model_builder.model.primary_key.unique_table_name
                     )

--- a/src/table_definition.rs
+++ b/src/table_definition.rs
@@ -17,9 +17,9 @@ pub struct PrimaryTableDefinition<'a> {
 pub struct NativeModelOptions {
     pub(crate) native_model_id: u32,
     pub(crate) native_model_version: u32,
-    // If a model as a new version, the old version is still available but marked as legacy.
-    // NOTE: Is impossible to write or read on a legacy table definition.
-    //       Just a migration to a new version is allowed.
+    // If a model has a new version, the old version is still available but marked as legacy.
+    // NOTE: It is impossible to write to or read from a legacy table definition.
+    //       Only migration to a new version is allowed.
     pub(crate) native_model_legacy: bool,
 }
 

--- a/src/transaction/internal/private_readable_transaction.rs
+++ b/src/transaction/internal/private_readable_transaction.rs
@@ -39,7 +39,7 @@ pub trait PrivateReadableTransaction<'db, 'txn> {
         key: impl ToKey,
     ) -> Result<Option<Output>> {
         let secondary_key = key_def.key_definition();
-        // Provide a better error for the test of unicity of the secondary key
+        // Provide a better error for testing the uniqueness of the secondary key.
         model.check_secondary_options(&secondary_key, |options| options.unique)?;
 
         let table = self.get_secondary_table(&model, &secondary_key)?;

--- a/src/transaction/query/get.rs
+++ b/src/transaction/query/get.rs
@@ -54,10 +54,10 @@ impl RGet<'_, '_> {
 
     /// Get a value from the database by secondary key.
     ///
-    /// /!\ The secondary key **must** be [`unique`](crate::models::Models#unique) else this method will return an error [`SecondaryKeyConstraintMismatch`](crate::db_type::Error::SecondaryKeyConstraintMismatch).
+    /// /!\ The secondary key **must** be [`unique`](crate::models::Models#unique); otherwise, this method will return an error [`SecondaryKeyConstraintMismatch`](crate::db_type::Error::SecondaryKeyConstraintMismatch).
     ///     If the secondary key is not unique, use [`scan()`](crate::transaction::RTransaction::scan) instead.
     ///
-    /// Anatomy of a secondary key it is a `enum` with the following structure: `<table_name>Key::<name>`.
+    /// The anatomy of a secondary key is an `enum` with the following structure: `<table_name>Key::<name>`.
     ///
     /// # Example
     /// ```rust

--- a/src/transaction/query/len.rs
+++ b/src/transaction/query/len.rs
@@ -46,7 +46,7 @@ impl RLen<'_, '_> {
 
     /// Get the number of values by secondary key.
     ///
-    /// Anatomy of a secondary key it is a `enum` with the following structure: `<table_name>Key::<name>`.
+    /// The anatomy of a secondary key is an `enum` with the following structure: `<table_name>Key::<name>`.
     ///
     /// If the secondary key is [`optional`](struct.Builder.html#optional) you will
     /// get all values that have the secondary key set.

--- a/src/transaction/query/scan/mod.rs
+++ b/src/transaction/query/scan/mod.rs
@@ -15,7 +15,7 @@ pub struct RScan<'db, 'txn> {
 }
 
 impl RScan<'_, '_> {
-    /// Get a values from the database by primary key.
+    /// Get values from the database by primary key.
     ///
     /// - [`all`](crate::transaction::query::PrimaryScan::all) - Scan all items.
     /// - [`start_with`](crate::transaction::query::PrimaryScan::start_with) - Scan items with a primary key starting with a key.
@@ -30,7 +30,7 @@ impl RScan<'_, '_> {
     }
 
     #[allow(clippy::type_complexity)]
-    /// Get a values from the database by secondary key.
+    /// Get values from the database by secondary key.
     ///
     /// - [`all`](crate::transaction::query::SecondaryScan::all) - Scan all items.
     /// - [`start_with`](crate::transaction::query::SecondaryScan::start_with) - Scan items with a secondary key starting with a key.
@@ -62,7 +62,7 @@ impl<'db, 'txn> RwScan<'db, 'txn>
 where
     'txn: 'db,
 {
-    /// Get a values from the database by primary key.
+    /// Get values from the database by primary key.
     ///
     /// - [`all`](crate::transaction::query::PrimaryScan::all) - Scan all items.
     /// - [`start_with`](crate::transaction::query::PrimaryScan::start_with) - Scan items with a primary key starting with a key.
@@ -77,7 +77,7 @@ where
     }
 
     #[allow(clippy::type_complexity)]
-    /// Get a values from the database by secondary key.
+    /// Get values from the database by secondary key.
     ///
     /// - [`all`](crate::transaction::query::SecondaryScan::all) - Scan all items.
     /// - [`start_with`](crate::transaction::query::SecondaryScan::start_with) - Scan items with a secondary key starting with a key.

--- a/src/transaction/query/scan/secondary_scan.rs
+++ b/src/transaction/query/scan/secondary_scan.rs
@@ -42,7 +42,7 @@ where
     /// If the secondary key is [`optional`](struct.Models.html#optional) you will
     /// get all values that have the secondary key set.
     ///
-    /// Anatomy of a secondary key it is a `enum` with the following structure: `<table_name>Key::<name>`.
+    /// The anatomy of a secondary key is an `enum` with the following structure: `<table_name>Key::<name>`.
     ///
     /// # Example
     /// ```rust
@@ -93,7 +93,7 @@ where
 
     /// Iterate over all values by secondary key in a range.
     ///
-    /// Anatomy of a secondary key it is a `enum` with the following structure: `<table_name>Key::<name>`.
+    /// The anatomy of a secondary key is an `enum` with the following structure: `<table_name>Key::<name>`.
     ///
     /// # Example
     /// ```rust
@@ -152,7 +152,7 @@ where
 
     /// Iterate over all values by secondary key starting with a prefix.
     ///
-    /// Anatomy of a secondary key it is a `enum` with the following structure: `<table_name>Key::<name>`.
+    /// The anatomy of a secondary key is an `enum` with the following structure: `<table_name>Key::<name>`.
     ///
     /// # Example
     /// ```rust

--- a/src/transaction/r_transaction.rs
+++ b/src/transaction/r_transaction.rs
@@ -10,8 +10,8 @@ pub struct RTransaction<'db> {
 impl<'db> RTransaction<'db> {
     /// Get a value from the database.
     ///
-    /// - [`primary`](crate::transaction::query::RGet::primary) - Get a item by primary key.
-    /// - [`secondary`](crate::transaction::query::RGet::secondary) - Get a item by secondary key.
+    /// - [`primary`](crate::transaction::query::RGet::primary) - Get an item by primary key.
+    /// - [`secondary`](crate::transaction::query::RGet::secondary) - Get an item by secondary key.
     pub fn get<'txn>(&'txn self) -> RGet<'db, 'txn> {
         RGet {
             internal: &self.internal,

--- a/src/transaction/rw_transaction.rs
+++ b/src/transaction/rw_transaction.rs
@@ -21,8 +21,8 @@ pub struct RwTransaction<'db> {
 impl<'db> RwTransaction<'db> {
     /// Get a value from the database.
     ///
-    /// - [`primary`](crate::transaction::query::RGet::primary) - Get a item by primary key.
-    /// - [`secondary`](crate::transaction::query::RGet::secondary) - Get a item by secondary key.
+    /// - [`primary`](crate::transaction::query::RGet::primary) - Get an item by primary key.
+    /// - [`secondary`](crate::transaction::query::RGet::secondary) - Get an item by secondary key.
     pub fn get<'txn>(&'txn self) -> RwGet<'db, 'txn> {
         RwGet {
             internal: &self.internal,
@@ -143,7 +143,7 @@ impl RwTransaction<'_> {
     ///
     /// If the primary key already exists, the value is updated.
     ///
-    /// Returns: the old value if the primary key already exists.
+    /// Returns the old value if the primary key already exists.
     ///
     /// # Example
     /// ```rust
@@ -259,7 +259,7 @@ impl RwTransaction<'_> {
     ///
     /// Update a value in the database.
     ///
-    /// That allow to update all keys (primary and secondary) of the value.
+    /// This allows updating all keys (primary and secondary) of the value.
     ///
     /// Returns error:
     /// - [crate::db_type::Error::KeyNotFound] if the `item` has a primary key that is not found in the database.
@@ -314,7 +314,7 @@ impl RwTransaction<'_> {
     ///
     /// Auto-update a value in the database.
     ///
-    /// Like upsert, but returns an error if the data does not exist instead of creating it.
+    /// Similar to upsert, but returns an error if the data does not exist, instead of creating it.
     ///
     /// Returns:
     /// - Ok(Some(T)) if the value was found and updated, containing the old value
@@ -470,22 +470,22 @@ impl RwTransaction<'_> {
     /// Automatically migrate the data from the old model to the new model. **No matter the state of the database**,
     /// if all models remain defined in the application as they are, the data will be migrated to the most recent version automatically.
     ///
-    /// Native DB use the [`native_model`](https://crates.io/crates/native_model) identifier `id` to identify the model and `version` to identify the version of the model.
+    /// Native DB uses the [`native_model`](https://crates.io/crates/native_model) identifier `id` to identify the model and `version` to identify the version of the model.
     /// We can define a model with the same identifier `id` but with a different version `version`.
     ///
-    /// In the example below we define one model with the identifier `id=1` with tow versions `version=1` and `version=2`.
+    /// In the example below, we define one model with the identifier `id=1` and two versions: `version=1` and `version=2`.
     /// - You **must** link the previous version from the new one with `from` option like `#[native_model(id=1, version=2, from=LegacyData)]`.
-    /// - You **must** define the interoperability between the two versions with implement `From<LegacyData> for Data` and `From<Data> for LegacyData` or implement `TryFrom<LegacyData> for Data` and `TryFrom<Data> for LegacyData`.
-    /// - You **must** define all models (by calling [`define`](crate::Models::define)) before to call [`migrate`](crate::transaction::RwTransaction::migrate).
-    /// - You **must** call use the most recent/bigger version as the target version when you call [`migrate`](crate::transaction::RwTransaction::migrate): `migration::<Data>()`.
-    ///   That means you can't call `migration::<LegacyData>()` because `LegacyData` has version `1` and `Data` has version `2`.
+    /// - You **must** define the interoperability between the two versions by implementing `From<LegacyData> for Data` and `From<Data> for LegacyData`, or by implementing `TryFrom<LegacyData> for Data` and `TryFrom<Data> for LegacyData`.
+    /// - You **must** define all models (by calling [`define`](crate::Models::define)) before calling [`migrate`](crate::transaction::RwTransaction::migrate).
+    /// - You **must** use the most recent/latest version as the target version when you call [`migrate`](crate::transaction::RwTransaction::migrate): `migration::<Data>()`.
+    ///   This means you can't call `migration::<LegacyData>()` because `LegacyData` has version `1` and `Data` has version `2`.
     ///
-    /// After call `migration::<Data>()` all data of the model `LegacyData` will be migrated to the model `Data`.
+    /// After calling `migration::<Data>()`, all data of the model `LegacyData` will be migrated to the model `Data`.
     ///
     /// Under the hood, when you call [`migrate`](crate::transaction::RwTransaction::migrate) `native_model` is used to convert the data from the old model to the new model
     /// using the `From` or `TryFrom` implementation for each to target the version defined when you call [`migrate::<LastVersion>()`](crate::transaction::RwTransaction::migrate).
     ///
-    /// It's advisable to perform all migrations within a **single transaction** to ensure that all migrations are successfully completed.
+    /// It is advisable to perform all migrations within a **single transaction** to ensure that all migrations are successfully completed.
     ///
     /// # Example
     /// ```rust
@@ -541,8 +541,8 @@ impl RwTransaction<'_> {
         self.internal.migrate::<T>()
     }
 
-    /// Refresh the data for the given model. Is used generally when during an database upgrade,
-    /// using the method [crate::Database::upgrading_from_version] (more details/example). Check release notes to know
+    /// Refresh the data for the given model. This is generally used during a database upgrade,
+    /// using the method [crate::Database::upgrading_from_version] (see more details/example). Check release notes to know
     /// when to use this method.
     pub fn refresh<T: ToInput + Debug>(&self) -> Result<()> {
         self.internal.refresh::<T>()


### PR DESCRIPTION
- Corrected grammar in README.md and benches/README.md.
- Skipped native_db_macro/README.md due to a persistent write error.
- Corrected grammar in Rust documentation comments in several files. Some files may have been missed due to the large number of files and issues I encountered.