### PR TITLE
Fix redb dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["database-implementations", "concurrency", "data-structures", "cac
 members = ["native_db_macro"]
 
 [dependencies]
-redb = "2.5.0"
+redb = "=2.5.0"
 redb1 = { version = "=1.5.1", package = "redb", optional = true }
 native_db_macro = { version = "0.8.1", path = "native_db_macro" }
 thiserror = "2.0.0"


### PR DESCRIPTION
The version of the `redb` dependency has been fixed to `2.5.0` by changing `redb = "2.5.0"` to `redb = "=2.5.0"` in `Cargo.toml`.

This change restricts the version of `redb` to exactly `2.5.0`, preventing unintended automatic updates to potentially incompatible newer versions.