### PR TITLE
docs: Add links to snapshot method in lib.rs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Here's a drop-in, fast, embedded database for multi-platform apps (server, deskt
 - **Thread-safe** and fully **ACID-compliant** transactions provided by [redb](https://github.com/cberner/redb).
 - **Real-time** subscription with filters for `insert`, `update` and `delete` operations.
 - Compatible with all Rust types (`enum`, `struct`, `tuple` etc.).
-- **Hot snapshots**.
+- **[Hot snapshots](https://docs.rs/native_db/latest/native_db/struct.Database.html#method.snapshot)**.
 
 # Installation
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 //! - [`Database`] - Database instance.
 //!    - [`compact`](crate::Database::compact) - Compact the database.
 //!    - [`check_integrity`](crate::Database::check_integrity) - Check the integrity of the database.
+//!    - [`snapshot`](crate::Database::snapshot) - Create a point-in-time snapshot of the database.
 //!    - [`rw_transaction`](crate::Database::rw_transaction) - Create a read-write transaction.
 //!       - [`insert`](crate::transaction::RwTransaction::insert) - Insert a item, fail if the item already exists.
 //!       - [`upsert`](crate::transaction::RwTransaction::upsert) - Upsert a item, update if the item already exists.


### PR DESCRIPTION
This commit updates src/lib.rs and README.md to include links to the Database::snapshot method documentation.

In src/lib.rs, a link was added to the API documentation section for Database methods. In README.md, the existing 'Hot snapshots' feature was updated to link to the docs.rs documentation page for the snapshot method.