### PR TITLE
feat: implement WatchScanSecondary::range and WatchScanPrimary::range

### DIFF
--- a/src/db_type/key/key.rs
+++ b/src/db_type/key/key.rs
@@ -2,7 +2,7 @@ use redb::{Key as RedbKey, TypeName, Value as RedbValue};
 use std::fmt::Debug;
 use std::ops::{Bound, Range, RangeBounds, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Ord, Eq, Hash)]
 pub struct Key(Vec<u8>);
 
 impl Key {
@@ -471,6 +471,7 @@ impl RedbKey for Key {
     }
 }
 
+#[derive(Clone, PartialEq, Eq)]
 pub enum KeyRange {
     Range(Range<Key>),
     RangeInclusive(RangeInclusive<Key>),

--- a/src/watch/filter.rs
+++ b/src/watch/filter.rs
@@ -10,6 +10,7 @@ pub(crate) struct TableFilter {
 pub(crate) enum KeyFilter {
     Primary(Option<Key>),
     PrimaryStartWith(Key),
+    PrimaryRange(KeyRange),
     Secondary(KeyDefinition<KeyOptions>, Option<Key>),
     SecondaryStartWith(KeyDefinition<KeyOptions>, Key),
     SecondaryRange(KeyDefinition<KeyOptions>, KeyRange),
@@ -27,6 +28,13 @@ impl TableFilter {
         Self {
             table_name,
             key_filter: KeyFilter::PrimaryStartWith(key_prefix.to_owned()),
+        }
+    }
+
+    pub(crate) fn new_primary_range(table_name: String, range: KeyRange) -> TableFilter {
+        Self {
+            table_name,
+            key_filter: KeyFilter::PrimaryRange(range),
         }
     }
 

--- a/src/watch/filter.rs
+++ b/src/watch/filter.rs
@@ -1,4 +1,4 @@
-use crate::db_type::{Key, KeyDefinition, KeyOptions, ToKeyDefinition};
+use crate::db_type::{Key, KeyDefinition, KeyOptions, KeyRange, ToKeyDefinition};
 
 #[derive(Eq, PartialEq, Clone)]
 pub(crate) struct TableFilter {
@@ -12,6 +12,7 @@ pub(crate) enum KeyFilter {
     PrimaryStartWith(Key),
     Secondary(KeyDefinition<KeyOptions>, Option<Key>),
     SecondaryStartWith(KeyDefinition<KeyOptions>, Key),
+    SecondaryRange(KeyDefinition<KeyOptions>, KeyRange),
 }
 
 impl TableFilter {
@@ -48,6 +49,17 @@ impl TableFilter {
         Self {
             table_name,
             key_filter: KeyFilter::SecondaryStartWith(key.key_definition(), key_prefix.to_owned()),
+        }
+    }
+
+    pub(crate) fn new_secondary_range<K: ToKeyDefinition<KeyOptions>>(
+        table_name: String,
+        key_def: &K,
+        range: KeyRange,
+    ) -> TableFilter {
+        Self {
+            table_name,
+            key_filter: KeyFilter::SecondaryRange(key_def.key_definition(), range),
         }
     }
 }

--- a/src/watch/query/internal.rs
+++ b/src/watch/query/internal.rs
@@ -67,6 +67,18 @@ impl InternalWatch<'_> {
         self.watch_generic(table_filter)
     }
 
+    pub(crate) fn watch_primary_range<T: ToInput, R: RangeBounds<impl ToKey>>(
+        &self,
+        range: R,
+    ) -> Result<(MpscReceiver<watch::Event>, u64)> {
+        let table_name = T::native_db_model().primary_key;
+        let table_filter = TableFilter::new_primary_range(
+            table_name.unique_table_name.clone(),
+            KeyRange::new(range),
+        );
+        self.watch_generic(table_filter)
+    }
+
     pub(crate) fn watch_secondary<T: ToInput>(
         &self,
         key_def: &impl ToKeyDefinition<KeyOptions>,

--- a/src/watch/query/scan.rs
+++ b/src/watch/query/scan.rs
@@ -1,5 +1,5 @@
 use crate::db_type::{
-    check_key_type, check_key_type_from_key_definition,
+    check_key_type, check_key_type_from_key_definition, check_range_key_range_bounds,
     check_range_key_range_bounds_from_key_definition, KeyDefinition, KeyOptions, Result, ToInput,
     ToKey, ToKeyDefinition,
 };
@@ -78,12 +78,46 @@ impl WatchScanPrimary<'_, '_> {
         self.internal.watch_primary_all::<T>()
     }
 
-    /// **TODO: needs to be implemented**
-    pub fn range<'a>(
+    /// Watch all values within a given range.
+    ///
+    /// # Example
+    /// ```rust
+    /// use native_db::*;
+    /// use native_db::native_model::{native_model, Model};
+    /// use serde::{Deserialize, Serialize};
+    ///
+    /// #[derive(Serialize, Deserialize)]
+    /// #[native_model(id=1, version=1)]
+    /// #[native_db]
+    /// struct Data {
+    ///     #[primary_key]
+    ///     id: i32,
+    ///     #[secondary_key]
+    ///     name: String,
+    ///     #[secondary_key]
+    ///     age: i32,
+    /// }
+    ///
+    /// fn main() -> Result<(), db_type::Error> {
+    ///     let mut models = Models::new();
+    ///     models.define::<Data>()?;
+    ///     let db = Builder::new().create_in_memory(&models)?;
+    ///     
+    ///     // Open a read transaction
+    ///     let r = db.r_transaction()?;
+    ///     
+    ///     // Watch all values by primary key between 1 and 10
+    ///     let (_recv, _id) = db.watch().scan().primary().range::<Data, _>(1..=10)?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn range<T: ToInput, R: RangeBounds<impl ToKey>>(
         &self,
-        _range: impl RangeBounds<&'a [u8]> + 'a,
+        range: R,
     ) -> Result<(MpscReceiver<watch::Event>, u64)> {
-        todo!()
+        let model = T::native_db_model();
+        check_range_key_range_bounds(&model, &range)?;
+        self.internal.watch_primary_range::<T, R>(range)
     }
 
     /// Watch all values starting with the given key.

--- a/src/watch/sender.rs
+++ b/src/watch/sender.rs
@@ -53,6 +53,11 @@ impl Watchers {
                             event_senders.push((*id, Arc::clone(event_sender)));
                         }
                     }
+                    KeyFilter::PrimaryRange(range) => {
+                        if range.contains(&request.primary_key) {
+                            event_senders.push((*id, Arc::clone(event_sender)));
+                        }
+                    }
                     KeyFilter::Secondary(key_def, key) => {
                         for (request_secondary_key_def, request_secondary_key) in
                             &request.secondary_keys_value

--- a/tests/watch/mod.rs
+++ b/tests/watch/mod.rs
@@ -455,7 +455,7 @@ fn watch_start_with_by_key() {
 }
 
 #[test]
-fn watch_range_by_key() {
+fn watch_range_by_primary() {
     let tf = TmpFs::new().unwrap();
 
     let mut models = Models::new();
@@ -464,6 +464,62 @@ fn watch_range_by_key() {
         .create(&models, tf.path("test").as_std_path())
         .unwrap();
 
+    let item_a_1_k = ItemA1K {
+        id: 0,
+        name: "a_1".to_string(),
+    };
+    let item_a_1_k = ItemA1K {
+        id: 1,
+        name: "a_1".to_string(),
+    };
+    let item_a_2_k = ItemA1K {
+        id: 2,
+        name: "a_2".to_string(),
+    };
+    let item_a_3_k = ItemA1K {
+        id: 3,
+        name: "b_1".to_string(),
+    };
+
+    let (recv, _) = db
+        .watch()
+        .scan()
+        .primary()
+        .range::<ItemA1K, _>(1u32..=2u32)
+        .unwrap();
+
+    let rw = db.rw_transaction().unwrap();
+    rw.insert(item_a_1_k.clone()).unwrap();
+    rw.insert(item_a_2_k.clone()).unwrap();
+    rw.insert(item_a_3_k.clone()).unwrap();
+    rw.commit().unwrap();
+
+    for _ in 0..2 {
+        let inner_event: ItemA1K = if let Event::Insert(event) = recv.recv_timeout(TIMEOUT).unwrap()
+        {
+            event.inner().unwrap()
+        } else {
+            panic!("wrong event")
+        };
+        assert!(inner_event == item_a_1_k || inner_event == item_a_2_k);
+    }
+    assert!(recv.try_recv().is_err());
+}
+
+#[test]
+fn watch_range_by_secondary() {
+    let tf = TmpFs::new().unwrap();
+
+    let mut models = Models::new();
+    models.define::<ItemA1K>().unwrap();
+    let db = Builder::new()
+        .create(&models, tf.path("test").as_std_path())
+        .unwrap();
+
+    let item_a_1_k = ItemA1K {
+        id: 0,
+        name: "a_1".to_string(),
+    };
     let item_a_1_k = ItemA1K {
         id: 1,
         name: "a_1".to_string(),


### PR DESCRIPTION
Fixes a TODO in `src/watch/query/scan.rs`. If this is OK, I can do the same for the primary key variant, but I think that one is less useful.