### PR TITLE
fix(ci): update nushell to version 0.105.1

### DIFF
--- a/.github/workflows/build_test_android.yml
+++ b/.github/workflows/build_test_android.yml
@@ -62,7 +62,7 @@ jobs:
       - run: just --version
       - uses: hustcer/setup-nu@v3.19
         with:
-          version: '0.85'
+          version: '0.105.1'
         env:
             GITHUB_TOKEN: ${{ secrets.PAT_GLOBAL }}
       # End install utilities

--- a/.github/workflows/build_test_ios.yml
+++ b/.github/workflows/build_test_ios.yml
@@ -40,7 +40,7 @@ jobs:
       - run: just --version
       - uses: hustcer/setup-nu@v3.19
         with:
-          version: '0.85'
+          version: '0.105.1'
         env:
             GITHUB_TOKEN: ${{ secrets.PAT_GLOBAL }}
       # End install utilities

--- a/.github/workflows/build_test_linux.yml
+++ b/.github/workflows/build_test_linux.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: extractions/setup-just@v3
       - uses: hustcer/setup-nu@v3.19
         with:
-          version: '0.85'
+          version: '0.105.1'
         env:
             GITHUB_TOKEN: ${{ secrets.PAT_GLOBAL }}
       - name: Just version
@@ -52,7 +52,7 @@ jobs:
       - uses: extractions/setup-just@v3
       - uses: hustcer/setup-nu@v3.19
         with:
-          version: '0.85'
+          version: '0.105.1'
         env:
             GITHUB_TOKEN: ${{ secrets.PAT_GLOBAL }}
       - name: Just version

--- a/.github/workflows/build_test_macos.yml
+++ b/.github/workflows/build_test_macos.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: extractions/setup-just@v3
       - uses: hustcer/setup-nu@v3.19
         with:
-          version: '0.85'
+          version: '0.105.1'
         env:
             GITHUB_TOKEN: ${{ secrets.PAT_GLOBAL }}
       - name: Just version

--- a/.github/workflows/build_test_windows.yml
+++ b/.github/workflows/build_test_windows.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: extractions/setup-just@v3
       - uses: hustcer/setup-nu@v3.19
         with:
-          version: '0.85'
+          version: '0.105.1'
         env:
             GITHUB_TOKEN: ${{ secrets.PAT_GLOBAL }}
       - name: Just version

--- a/.github/workflows/clippy_check.yml
+++ b/.github/workflows/clippy_check.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: extractions/setup-just@v3
       - uses: hustcer/setup-nu@v3.19
         with:
-          version: '0.85'
+          version: '0.105.1'
         env:
             GITHUB_TOKEN: ${{ secrets.PAT_GLOBAL }}
       - name: Just version

--- a/.github/workflows/fmt_check.yml
+++ b/.github/workflows/fmt_check.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: extractions/setup-just@v3
       - uses: hustcer/setup-nu@v3.19
         with:
-          version: '0.85'
+          version: '0.105.1'
         env:
             GITHUB_TOKEN: ${{ secrets.PAT_GLOBAL }}
       - name: Just version


### PR DESCRIPTION
This change updates the version of Nushell used in the GitHub Actions workflows from 0.85 to 0.105.1.

The previous version (0.85.0) was causing errors as it was no longer available or a valid release specifier for the setup-nu action. Updating to 0.105.1, the latest stable version at the time of this commit, resolves these errors and ensures the CI jobs can run successfully with an up-to-date Nushell environment.