### PR TITLE
feat: Configure Renovate to update Nushell versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,13 @@
       "depNameTemplate": "native_model",
       "datasourceTemplate": "crate",
       "versioningTemplate": "semver"
+    },
+    {
+      "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$"],
+      "matchStrings": ["uses: hustcer/setup-nu@.*?\n.*?version: '\\s*(?<currentValue>.*?)'"],
+      "depNameTemplate": "nushell",
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "nushell/nushell"
     }
   ],
   "enabled": true


### PR DESCRIPTION
Adds a regexManager to `renovate.json` to enable Renovate to detect and update Nushell versions used in your GitHub Actions workflows.

This configuration targets the `hustcer/setup-nu` action and extracts the version from the `with: version:` field. The datasource is set to `github-releases` for `nushell/nushell`.