### PR TITLE
Add example test file

### DIFF
--- a/tests/test_example.rs
+++ b/tests/test_example.rs
@@ -1,0 +1,15 @@
+#[cfg(test)]
+mod tests {
+    use native_db::DatabaseBuilder;
+
+    #[test]
+    fn test_example() {
+        // This is just a simple example test
+        let db = DatabaseBuilder::new()
+            .memory()
+            .build()
+            .expect("Failed to create database");
+
+        assert!(db.is_memory());
+    }
+}


### PR DESCRIPTION
This PR adds a simple example test file to demonstrate basic database creation and testing.

Changes:
- Added `tests/test_example.rs` with a basic test that creates an in-memory database
- Test verifies that the database is properly created in memory mode

Note: There might be a linter error regarding the `DatabaseBuilder` import that needs to be addressed.