### PR TITLE
chore: add .cursor/ directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ Cargo.lock
 tests/data/db_x_x_x
 
 .DS_Store
+# IDE specific
+.cursor/


### PR DESCRIPTION
This PR adds the `.cursor/` directory to `.gitignore` to prevent IDE-specific files from being tracked in version control.

Changes:
- Added `.cursor/` to `.gitignore` under IDE specific section
- Added a newline for better organization of the file

This change will help keep the repository clean from IDE-specific files that should not be tracked in version control.