### PR TITLE
feat: allow generic `Key` to pass type checking

### DIFF
--- a/src/db_type/key/key_definition.rs
+++ b/src/db_type/key/key_definition.rs
@@ -87,6 +87,8 @@ fn _check_key_type_from_key_definition<K: ToKey>(
     if !K::key_names()
         .iter()
         .any(|name| key_definition.rust_types.contains(name))
+        // If passed a generic `Key`, disable type checks as we assume this was intentional
+        && K::key_names() != Key::key_names()
     {
         return Err(Error::MissmatchedKeyType {
             key_name: key_definition.unique_table_name.to_string(),


### PR DESCRIPTION
I'm running into a problem with key type checking because I've already converted my `impl ToKey` into a `Key` by the time I pass it to the secondary scan:

```rust
key: KeyDefinition<KeyOptions>
key_value: Key

scan.secondary(key)?.equal(key_value)?.try_collect()? // Mismatched key type error
```

I can't easily get the original type back since it's stored in a `struct` (which isn't generic over the key type). I think this check can be bypassed when the key type is a generic `Key`.